### PR TITLE
Feature/counter history 10min

### DIFF
--- a/src/components/Menu/InstanceSelector/InstanceSelector.js
+++ b/src/components/Menu/InstanceSelector/InstanceSelector.js
@@ -88,6 +88,8 @@ class InstanceSelector extends Component {
                                 instances = msg.result;
 
                                 if (instances) {
+                                    instances.sort((a, b) => a.objName < b.objName ? -1 : 1);
+
                                     const hosts = {};
                                     instances.filter((o) => o.objFamily === 'host').forEach((o) => {
                                         hosts[o.objName] = o;
@@ -218,18 +220,22 @@ class InstanceSelector extends Component {
                     activeServerId: serverId
                 });
 
-                // find host
                 const instances = msg.result;
-                const hosts = {};
-                instances.filter((o) => o.objFamily === 'host').forEach((o) => {
-                    hosts[o.objName] = o;
-                });
+                if (instances) {
+                    instances.sort((a, b) => a.objName < b.objName ? -1 : 1);
 
-                instances.filter((o) => o.objFamily === 'javaee').forEach((o) => {
-                    let instanceName = o.objName;
-                    let hostName = instanceName.substring(0, instanceName.lastIndexOf('/'));
-                    o.host = hosts[hostName];
-                });
+                    // find host
+                    const hosts = {};
+                    instances.filter((o) => o.objFamily === 'host').forEach((o) => {
+                        hosts[o.objName] = o;
+                    });
+
+                    instances.filter((o) => o.objFamily === 'javaee').forEach((o) => {
+                        let instanceName = o.objName;
+                        let hostName = instanceName.substring(0, instanceName.lastIndexOf('/'));
+                        o.host = hosts[hostName];
+                    });
+                }
             }
 
             this.setState({

--- a/src/components/Paper/LineChart/LineChart.js
+++ b/src/components/Paper/LineChart/LineChart.js
@@ -85,6 +85,7 @@ class LineChart extends Component {
             for(const timeKey in timeKeyRow) {
                 counters[counterKey].push(timeKeyRow[timeKey]);
             }
+            counters[counterKey].sort((a,b) => a.time - b.time);
         }
 
         let counters = Object.assign(this.state.counters);


### PR DESCRIPTION
* 최초에 카운터 10분 데이터 로드시 처리 수정
  - 여러개 인스턴스 조회시 실시간 카운터 조회와 역전되어 때때로 데이터가 제대로 그려지지 않는 부분 수정
  - 10분 데이터 조회시 time을 scouter의 최소 수집 주기인 2초 간격으로 trunc.
  - 실시간 카운터 조회는 10분 데이터 로드 이후에 진행되도록 변경