### PR TITLE
프로파일 error stack trace 헤더 정보 렌더링 개선

### DIFF
--- a/src/components/Paper/XLog/Profiler/FrameProfile/FrameProfile.css
+++ b/src/components/Paper/XLog/Profiler/FrameProfile/FrameProfile.css
@@ -51,6 +51,7 @@
 
 .frame-profile div.xlog-data span.data.error {
     color: #FF030D;
+    white-space: pre;
 }
 
 .frame-profile div.xlog-data span.data.tx-link {

--- a/src/components/Paper/XLog/Profiler/FrameProfile/FrameProfile.js
+++ b/src/components/Paper/XLog/Profiler/FrameProfile/FrameProfile.js
@@ -502,7 +502,10 @@ class FrameProfile extends Component {
                                 {meta.type === "bytes" && `${numeral(this.props.profile[meta.key]).format(this.props.config.numberFormat)} b`}
                                 {meta.type === "number" && numeral(this.props.profile[meta.key]).format(this.props.config.numberFormat)}
                                 {meta.type === "boolean" && this.boolTostr(this.props.profile[meta.key]) }
-                                {(meta.type !== "datetime" && meta.type !== "ms" && meta.type !== "bytes" && meta.type !== "number" && meta.type !== "boolean") && this.props.profile[meta.key]}
+                                {
+                                    (meta.type !== "datetime" && meta.type !== "ms" && meta.type !== "bytes" && meta.type !== "number" && meta.type !== "boolean") &&
+                                    this.props.profile[meta.key]
+                                }
                             </span>
                         </div>
                     })}


### PR DESCRIPTION
#270 ⚡️ profile error stack trace 헤더 정보 렌더링 개선

## before 
![image](https://user-images.githubusercontent.com/18545293/147671657-0c8abca0-7176-42e8-bd8a-cee25fd6aeab.png)

## after
![image](https://user-images.githubusercontent.com/18545293/147671756-da9e1b01-bd20-46b6-b3cc-eb031d42ad30.png)


CSS 내용으로 개선 진행함 
 